### PR TITLE
Add TLS option handling in LDAP mavis module

### DIFF
--- a/mavis/Controllers/LDAP/LDAP.php
+++ b/mavis/Controllers/LDAP/LDAP.php
@@ -177,8 +177,8 @@ class LDAP extends Controller
 
     $username = ( strpos($this->ldap->user, '@') !== false ) ? $this->ldap->user : $this->ldap->user . '@'.( str_replace( ',', '.', preg_replace('/DC=/i', '', $this->ldap->base) ) );
 
-		$username = ( $this->ldap->type == 'openldap' ) ? $this->ldap->user : $username;
-
+    $username = ( $this->ldap->type == 'openldap' ) ? $this->ldap->user : $username;
+	  
     $config = [
     	// Mandatory Configuration Options
     	'hosts'            => array_map('trim', explode(',', $this->ldap->hosts) ),
@@ -188,6 +188,7 @@ class LDAP extends Controller
     	// Optional Configuration Options
     	'schema'           => ( $this->ldap->type == 'openldap' ) ? OpenLDAP::class : ActiveDirectory::class,
     	'port'             => $this->ldap->port,
+	'use_tls'          => ( $this->ldap->tls == 1 ? true : false ),
     	'version'          => 3,
     	'timeout'          => 5,
     ];
@@ -199,10 +200,10 @@ class LDAP extends Controller
     $this->ad->addProvider($config);
 
     try {
-    		$this->mavis->debugIn( $this->dPrefix() .'Attempt to connect');
-        $this->provider = $this->ad->connect();
+	    $this->mavis->debugIn( $this->dPrefix() .'Attempt to connect');
+	    $this->provider = $this->ad->connect();
     } catch (\Adldap\Auth\BindException $e) {
-    		$this->mavis->debugIn( $this->dPrefix() .'Connect FAIL! '.$e->getMessage().' Exit.');
+	    $this->mavis->debugIn( $this->dPrefix() .'Connect FAIL! '.$e->getMessage().' Exit.');
         return false;
     }
     return true;


### PR DESCRIPTION
If tls == 1 in the mavis_ldap database record, set ldap use_tls to true, else false

Minor formatting changes nearby

You use port 389 as normal for TLS, I have verified that the connection is encrypted after setting tls=1 in the database with this minor patch by packet capturing the traffic between tacgui and the LDAP server on port 389.

**NB** The OS must trust the CA that signed the certificate that the LDAP server is using. 

On ubuntu, to add your AD CA cert, this is fairly straightforward;

Export the CA certificate Base64 formatted
Add the Base64 encoded CA certificate to `/usr/local/share/ca-certificates/` , with a .crt extension
run 
`sudo update-ca-certificates`

Obviously, this requires the uncommenting of the TLS checkbox HTML in the web ui file (web/mavis_ldap.php line 107) to make the TLS flag accessible in the web ui. I can't submit a single PR using the github patch interface to do that.